### PR TITLE
impose term limits on factorise

### DIFF
--- a/FibPseudoprime.cabal
+++ b/FibPseudoprime.cabal
@@ -28,6 +28,7 @@ library
       Benchmarking
       Lib
       Sort
+      TimeLimits
   other-modules:
       Paths_FibPseudoprime
   hs-source-dirs:
@@ -37,7 +38,10 @@ library
     , arithmoi
     , base >=4.7 && <5
     , criterion
+    , deepseq
     , hspec
+    , random
+    , stm
     , text
   default-language: Haskell2010
 
@@ -54,7 +58,10 @@ executable FibPseudoprime-exe
     , arithmoi
     , base >=4.7 && <5
     , criterion
+    , deepseq
     , hspec
+    , random
+    , stm
     , text
   default-language: Haskell2010
 
@@ -72,6 +79,9 @@ test-suite FibPseudoprime-test
     , arithmoi
     , base >=4.7 && <5
     , criterion
+    , deepseq
     , hspec
+    , random
+    , stm
     , text
   default-language: Haskell2010

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,6 +5,7 @@ import Math.NumberTheory.Primes
 import Data.Text as T
 import Data.Text.IO as T.IO
 import Data.List as L
+import TimeLimits
 
 printFibFactors :: (Int, Integer, [Integer]) -> IO ()
 printFibFactors (n, fibn, factors) = do 
@@ -14,13 +15,23 @@ printFibFactors (n, fibn, factors) = do
 hundred :: Int -> [Int]
 hundred n = [n * 100 + 1, (n * 100) + 2 .. (n * 100) + 100]
 
-createOutput :: Int -> IO()
-createOutput n = do
+createOutputOriginal :: Int -> IO()
+createOutputOriginal n = do
     T.IO.writeFile ("output/output_" ++ show (n * 100 + 1) ++ "-" ++ show (n * 100 + 100) ++ ".txt") 
-        (T.map (\c -> if c == '(' then '[' else if c == ')' then ']' else c) $ 
-            T.pack $
-            show $ L.map carlTest $ hundred n)
+        --  $ T.map (\c -> if c == '(' then '[' else if c == ')' then ']' else c)
+            $ T.pack
+            $ show $ L.map carlTest $ hundred n
     print ("Finished [" ++ show (n * 100 + 1) ++ " .. " ++ show (n * 100 + 100) ++ "].")
 
+createOutputTermLimits :: Int -> IO()
+createOutputTermLimits n = do
+    factorList <- mapM carlTestTermLimits $ hundred n
+    T.IO.writeFile ("output/output_" ++ show (n * 100 + 1) ++ "-" ++ show (n * 100 + 100) ++ ".txt") 
+        --  $ T.map (\c -> if c == '(' then '[' else if c == ')' then ']' else c)
+            $ T.pack
+            $ show $ factorList
+    print ("Finished [" ++ show (n * 100 + 1) ++ " .. " ++ show (n * 100 + 100) ++ "].")
+
+
 main :: IO ()
-main = mapM_ (createOutput) [0, 1 .. ]
+main = mapM_ (createOutputTermLimits) [0, 1 .. ]

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,9 @@ dependencies:
 - QuickCheck
 - criterion
 - text
+- random
+- stm
+- deepseq
 
 library:
   source-dirs: src

--- a/src/TimeLimits.hs
+++ b/src/TimeLimits.hs
@@ -1,0 +1,32 @@
+module TimeLimits
+  ( 
+    timeLimited
+  ) where
+
+import Control.Concurrent.STM
+import Control.DeepSeq
+import System.Timeout
+
+type Time = Int
+
+-- | Compute as many items of a list in given timeframe (microseconds)
+--   This is done by running a function that computes (with `force`)
+--   list items and pushed them onto a `TVar [a]`.  When the requested time
+--   expires, ghc will terminate the execution of `forceIntoTVar`, and we'll
+--   return what has been pushed onto the tvar.
+timeLimited :: (NFData a) => Time -> Integer -> [a] -> IO [a]
+timeLimited t x xs = do
+    v <- newTVarIO []
+    results <- timeout t (forceIntoTVar xs v)
+    case results of
+        Just a -> return ()
+        Nothing -> print("Complete factorization failed at: " ++ show x)
+    readTVarIO v 
+
+-- | Force computed values into given tvar
+forceIntoTVar :: (NFData a) => [a] -> TVar [a] -> IO [()]
+forceIntoTVar xs v = mapM (atomically . modifyTVar v . forceCons) xs
+
+-- | Returns function that does actual computation and cons' to tvar value
+forceCons :: (NFData a) => a -> [a] -> [a]
+forceCons x = (force x:)

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,7 +36,6 @@ packages:
 # forks / in-progress versions pinned to a git hash. For example:
 #
 extra-deps:
-  - HaskellForMaths-0.4.9@sha256:96f682ccc369ca71538d49ab6a91a085a7d35e39e29ccc8b0f2ee878c1887b91,4342
 # - acme-missiles-0.3
 # - git: https://github.com/commercialhaskell/stack.git
 #   commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,14 +3,7 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: HaskellForMaths-0.4.9@sha256:96f682ccc369ca71538d49ab6a91a085a7d35e39e29ccc8b0f2ee878c1887b91,4342
-    pantry-tree:
-      size: 6674
-      sha256: cc3b461a071fdcccf72c409d2f884fabe7ca283276f53c77bf11598ef6462d6d
-  original:
-    hackage: HaskellForMaths-0.4.9@sha256:96f682ccc369ca71538d49ab6a91a085a7d35e39e29ccc8b0f2ee878c1887b91,4342
+packages: []
 snapshots:
 - completed:
     size: 563100


### PR DESCRIPTION
Created a timeout function that spits out results of a number's factorization after a timeout is reached. If factorization fails, it writes to the console log the number it failed on.